### PR TITLE
Added documentation and improved Mix tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ cd toothpick
 ### Compiling and running the application
 
 ```bash
-mix tokenize path/to/source/file.tp # To get tokens list
-mix parse path/to/source/file.tp # To get toothpick-AST
-# WIP # mix compile path/to/source/file.tp # To get JavaScript-AST
-# WIP # mix js path/to/source/file.tp # To get JavaScript code
-# WIP # mix run path/to/source/file.tp # To get output of the program embedded in the file.tp file (runs the JavaScript compiler and runs the program with Node.JS)
+mix tokenize test/stubs/function_without_arguments.tp `# returns the tokens list` \
+| mix parse `# parses the tokens list and returns the Toothpick AST` \
+| mix translate `# translates the Toothpick AST to JS AST` \
+| node node_modules/js-ast-compiler/compile.js `# compiles the JS AST to JS code` \
+| node `# runs the code`
 ```
 
 ### Running tests

--- a/lib/tasks/helpers/content_reader.ex
+++ b/lib/tasks/helpers/content_reader.ex
@@ -1,0 +1,9 @@
+defmodule Tasks.Helpers.ContentReader do
+  def get_content(argv) do
+    cond do
+      length(argv) == 0 -> IO.read(:all)
+      length(argv) == 1 -> argv |> List.first() |> File.read!()
+      true -> raise("This task expects either 0 or 1 argument. Refer to manual for more information.")
+    end
+  end
+end

--- a/lib/tasks/helpers/elixir_parser.ex
+++ b/lib/tasks/helpers/elixir_parser.ex
@@ -1,0 +1,32 @@
+defmodule Tasks.Helpers.ElixirParser do
+  def parse(str) when is_binary(str) do
+    case str |> Code.string_to_quoted() do
+      {:ok, terms} -> _parse(terms)
+      {:error, _} -> {:invalid_terms}
+    end
+  end
+
+  # atomic terms
+  defp _parse(term) when is_atom(term), do: term
+  defp _parse(term) when is_integer(term), do: term
+  defp _parse(term) when is_float(term), do: term
+  defp _parse(term) when is_binary(term), do: term
+
+  defp _parse([]), do: []
+  defp _parse([h | t]), do: [_parse(h) | _parse(t)]
+
+  defp _parse({a, b}), do: {_parse(a), _parse(b)}
+
+  defp _parse({:{}, _place, terms}) do
+    terms
+    |> Enum.map(&_parse/1)
+    |> List.to_tuple()
+  end
+
+  defp _parse({:%{}, _place, terms}) do
+    for {k, v} <- terms, into: %{}, do: {_parse(k), _parse(v)}
+  end
+
+  # to ignore functions and operators
+  defp _parse({_term_type, _place, terms}), do: terms
+end

--- a/lib/tasks/parser.ex
+++ b/lib/tasks/parser.ex
@@ -1,12 +1,51 @@
 defmodule Mix.Tasks.Parse do
+  @moduledoc """
+  Parses Toothpick tokens list to the Toothpick AST.
+
+  This task receives a Toothpick tokens list as input and
+  outputs the Toothpick AST:
+
+      mix parse file/containing/toothpick/tokens/list.txt
+
+  It is also possible to pass the file contents in stdin:
+
+      cat file/containing/toothpick/tokens/list.txt | mix parse
+
+  ## Example
+
+  ### Input
+
+      echo '[
+        keyword: "fun",
+        identifier: "main",
+        punctuator: "->",
+        new_line: "\\n",
+        keyword: "return",
+        string: "Hello, World!",
+        new_line: "\\n",
+        punctuator: ".",
+        new_line: "\\n"
+      ]' | mix parse
+
+  ### Output
+
+      [
+        function_declaration: [
+          identifier: "main",
+          function_arguments: [],
+          function_body: [return_statement: {:string, "Hello, World!"}]
+        ]
+      ]
+  """
+
+  @shortdoc "Parse Toothpick tokens to AST"
+
   use Mix.Task
 
-  @shortdoc "Tokenize and parse toothpick source code"
-
   def run(argv) do
-    List.first(argv)
-    |> File.read!()
-    |> Toothpick.Tokenizer.tokens()
+    argv
+    |> Tasks.Helpers.ContentReader.get_content()
+    |> Tasks.Helpers.ElixirParser.parse()
     |> Toothpick.Parser.parse()
     |> IO.inspect(pretty: true)
   end

--- a/lib/tasks/tokenizer.ex
+++ b/lib/tasks/tokenizer.ex
@@ -1,11 +1,46 @@
 defmodule Mix.Tasks.Tokenize do
+  @moduledoc """
+  Tokenizes the Toothpick source code.
+
+  This task receives a Toothpick source code as input and
+  outputs the tokens list:
+
+      mix tokenize tokenize/some/particular/file.tp
+
+  It is also possible to pass the file contents in stdin:
+
+      cat tokenize/some/particular/file.tp | mix tokenize
+
+  ## Example
+
+  ### Input
+
+      echo "fun main ->
+        return 'Hello, World!'
+      ." | mix tokenize
+
+  ### Output
+
+      [
+        keyword: "fun",
+        identifier: "main",
+        punctuator: "->",
+        new_line: "\\n",
+        keyword: "return",
+        string: "Hello, World!",
+        new_line: "\\n",
+        punctuator: ".",
+        new_line: "\\n"
+      ]
+  """
+
+  @shortdoc "Tokenize Toothpick source code"
+
   use Mix.Task
 
-  @shortdoc "Tokenize toothpick source code"
-
   def run(argv) do
-    List.first(argv)
-    |> File.read!()
+    argv
+    |> Tasks.Helpers.ContentReader.get_content()
     |> Toothpick.Tokenizer.tokens()
     |> IO.inspect(pretty: true)
   end


### PR DESCRIPTION
- Added documentation
![](https://i.imgur.com/pKMkIp5.png)

- Made it possible to chain commands:
```bash
mix tokenize test/stubs/function_without_arguments.tp `# returns the tokens list` \
| mix parse `# parses the tokens list and returns the Toothpick AST` \
| mix translate `# translates the Toothpick AST to JS AST` \
| node node_modules/js-ast-compiler/compile.js `# compiles the JS AST to JS code` \
| node `# runs the code`
```